### PR TITLE
fix(struct): encode false and null fields correctly

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -128,7 +128,7 @@ export const struct = {
     const fields = {};
     Object.keys(json).forEach(key => {
       // If value is undefined, do not encode it.
-      if (json[key] === undefined) return;
+      if (typeof json[key] === 'undefined') return;
       fields[key] = value.encode(json[key]);
     });
     return {fields};

--- a/index.ts
+++ b/index.ts
@@ -128,7 +128,7 @@ export const struct = {
     const fields = {};
     Object.keys(json).forEach(key => {
       // If value is undefined, do not encode it.
-      if (!json[key]) return;
+      if (json[key] === undefined) return;
       fields[key] = value.encode(json[key]);
     });
     return {fields};

--- a/test.ts
+++ b/test.ts
@@ -5,12 +5,14 @@ const arr = [null, 10];
 
 const obj = {
   foo: 'bar',
-  yes: true
+  no: false,
+  nil: null
 };
 
 const objWithUndefined = {
   foo: 'bar',
-  yes: true,
+  no: false,
+  nil: null,
   isUndefined: undefined
 };
 
@@ -30,9 +32,13 @@ const structValue = {
       kind: 'stringValue',
       stringValue: 'bar'
     },
-    yes: {
+    no: {
       kind: 'boolValue',
-      boolValue: true
+      boolValue: false
+    },
+    nil: {
+      kind: 'nullValue',
+      nullValue: 0
     }
   }
 };


### PR DESCRIPTION
Hi! :)

I noticed that false and null fields in structs are not encoded and based on the comment in [line 130](https://github.com/callmehiphop/pb-util/pull/4/files#diff-ed009b6b86b017532ef0489c77de5100L130) I suppose it's not intended.

---

**Before:**

![image](https://user-images.githubusercontent.com/15332326/62625510-a2eed380-b925-11e9-816d-ae2bad23da97.png)

**After:**

![image](https://user-images.githubusercontent.com/15332326/62625551-bac65780-b925-11e9-82a6-0fc34318d235.png)
