### PR TITLE
Allow Different Kinds of `nullValue`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -33,12 +33,12 @@ export type JsonValue = string|number|boolean|null|JsonObject|JsonArray;
  */
 export interface Value {
   kind?: string;
-  nullValue?: number;
-  numberValue?: number;
-  stringValue?: string;
-  boolValue?: boolean;
-  structValue?: Struct;
-  listValue?: ListValue;
+  nullValue?: number | 'NULL_VALUE' | null;
+  numberValue?: number | null;
+  stringValue?: string | null;
+  boolValue?: boolean | null;
+  structValue?: Struct | null;
+  listValue?: ListValue | null;
 }
 
 /**
@@ -46,7 +46,7 @@ export interface Value {
  * @property {Object.<string, Value>} fields The struct fields.
  */
 export interface Struct {
-  fields?: {[key: string]: Value};
+  fields?: {[key: string]: Value} | null;
 }
 
 /**
@@ -54,7 +54,7 @@ export interface Struct {
  * @property {Value[]} values The list values.
  */
 export interface ListValue {
-  values?: Value[];
+  values?: Value[] | null;
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -23,13 +23,13 @@ export type JsonValue = string|number|boolean|null|JsonObject|JsonArray;
  *     - `boolValue`
  *     - `structValue`
  *     - `listValue`
- * @property {number} [nullValue] Represents a null value, actual field value
+ * @property {number | 'NULL_VALUE' | null} [nullValue] Represents a null value, actual field value
  *     should be `0`.
- * @property {number} [numberValue] Represents a number.
- * @property {string} [stringValue] Represents a string.
- * @property {boolean} [boolValue] Represents a boolean.
- * @property {Struct} [structValue] Represents an object.
- * @property {ListValue} [listValue] Represents an array of values.
+ * @property {number | null} [numberValue] Represents a number.
+ * @property {string | null} [stringValue] Represents a string.
+ * @property {boolean | null} [boolValue] Represents a boolean.
+ * @property {Struct | null} [structValue] Represents an object.
+ * @property {ListValue | null} [listValue] Represents an array of values.
  */
 export interface Value {
   kind?: string;
@@ -51,7 +51,7 @@ export interface Struct {
 
 /**
  * @typedef {Object} ListValue
- * @property {Value[]} values The list values.
+ * @property {Value[] | null} values The list values.
  */
 export interface ListValue {
   values?: Value[] | null;

--- a/index.ts
+++ b/index.ts
@@ -176,6 +176,7 @@ export const struct = {
    * @returns {Object.<string, *>}
    */
   decode({fields = {}}: Struct): JsonObject {
+    if (fields === null) return null;
     const json = {};
     Object.keys(fields).forEach(key => {
       json[key] = value.decode(fields[key]);
@@ -206,6 +207,7 @@ export const list = {
    * @returns {Array.<*>}
    */
   decode({values = []}: ListValue): JsonArray {
+    if (values === null) return null;
     return values.map(value.decode);
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pb-util",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Utilities for working with common protobuf types",
   "main": "build",
   "files": [

--- a/test.ts
+++ b/test.ts
@@ -119,6 +119,16 @@ test('value.decode - listValue', t => {
   t.deepEqual(actual, arr);
 });
 
+test('value.decode - listValue is null', t => {
+  const encodedValue = {
+    kind: 'listValue',
+    listValue: { values: null }
+  };
+
+  const actual = value.decode(encodedValue);
+  t.is(actual, null);
+});
+
 test('value.decode - structValue', t => {
   const encodedValue = {
     kind: 'structValue',
@@ -127,6 +137,16 @@ test('value.decode - structValue', t => {
 
   const actual = value.decode(encodedValue);
   t.deepEqual(actual, obj);
+});
+
+test('value.decode - structValue is null', t => {
+  const encodedValue = {
+    kind: 'structValue',
+    structValue: { fields: null }
+  };
+
+  const actual = value.decode(encodedValue);
+  t.is(actual, null);
 });
 
 test('value.decode - nullValue 0', t => {
@@ -169,6 +189,16 @@ test('value.decode - stringValue', t => {
   t.is(actual, 'foo');
 });
 
+test('value.decode - stringValue is null', t => {
+  const encodedValue = {
+    kind: 'stringValue',
+    stringValue: null
+  };
+
+  const actual = value.decode(encodedValue);
+  t.is(actual, null);
+});
+
 test('value.decode - numberValue', t => {
   const encodedValue = {
     kind: 'numberValue',
@@ -179,6 +209,16 @@ test('value.decode - numberValue', t => {
   t.is(actual, 10);
 });
 
+test('value.decode - numberValue is null', t => {
+  const encodedValue = {
+    kind: 'numberValue',
+    numberValue: null
+  };
+
+  const actual = value.decode(encodedValue);
+  t.is(actual, null);
+});
+
 test('value.decode - boolValue', t => {
   const encodedValue = {
     kind: 'boolValue',
@@ -187,6 +227,16 @@ test('value.decode - boolValue', t => {
 
   const actual = value.decode(encodedValue);
   t.is(actual, true);
+});
+
+test('value.decode - boolValue is null', t => {
+  const encodedValue = {
+    kind: 'boolValue',
+    boolValue: null
+  };
+
+  const actual = value.decode(encodedValue);
+  t.is(actual, null);
 });
 
 // https://github.com/callmehiphop/pb-util/issues/5

--- a/test.ts
+++ b/test.ts
@@ -129,10 +129,30 @@ test('value.decode - structValue', t => {
   t.deepEqual(actual, obj);
 });
 
-test('value.decode - nullValue', t => {
+test('value.decode - nullValue 0', t => {
   const encodedValue = {
     kind: 'nullValue',
     nullValue: 0
+  };
+
+  const actual = value.decode(encodedValue);
+  t.is(actual, null);
+});
+
+test('value.decode - nullValue NULL_VALUE', t => {
+  const encodedValue = {
+    kind: 'nullValue',
+    nullValue: 'NULL_VALUE' as const
+  };
+
+  const actual = value.decode(encodedValue);
+  t.is(actual, null);
+});
+
+test('value.decode - nullValue null', t => {
+  const encodedValue = {
+    kind: 'nullValue',
+    nullValue: null
   };
 
   const actual = value.decode(encodedValue);


### PR DESCRIPTION
This is related to #17, but I don't believe it fixes it.

Credit to @orgads for the actual fix, I just pulled it in from their fork and added a few tests. The motivation for this change from my perspective is that a lot of Google libraries which use protobufs have types that may allow null values.

See definitions:
* [Interface protos.google.protobuf.IStruct ](https://cloud.google.com/nodejs/docs/reference/aiplatform/latest/aiplatform/protos.google.protobuf.istruct)
* [Interface protos.google.protobuf.IValue](https://cloud.google.com/nodejs/docs/reference/dataflow/latest/dataflow/protos.google.protobuf.ivalue)

Admittedly, my test coverage on these changes probably isn't great, but I'm happy to add more if you have suggestions. 🙂 